### PR TITLE
fixes null value condition

### DIFF
--- a/scripts/security.py
+++ b/scripts/security.py
@@ -118,7 +118,7 @@ def ssh_group_access_check():
         if "com.apple.access_ssh-disabled" in out:
             # if this group exists, all users are permitted to access SSH.
             # Nothing group specific
-            pass
+            return ''
 
         elif "com.apple.access_ssh" in out:
             # Get a list of UUIDs of Nested Groups
@@ -139,7 +139,7 @@ def ssh_group_access_check():
             # If neither SSH group exists but SSH is enabled, it was turned on with
             # systemsetup and all users are enabled.
             # Nothing group specific
-            pass
+            return ''
 
 def ard_access_check():
     """Check for local users who have ARD permissions


### PR DESCRIPTION
FoundationPlist would crash when passed a None value. Make the script pass an empty string instead, which MR will interpret properly anyhow. Fixes #4 