### PR TITLE
Add secure boot and external boot settings detection

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -4,9 +4,13 @@
     "block_all": "Block All",
     "firewall_state": "Firewall State",
     "firmwarepw": "Firmware Password",
+    "full": "Full",
     "gatekeeper": "Gatekeeper Status",
     "gatekeeper_active": "Gatekeeper Active",
     "gatekeeper_disabled": "Gatekeeper Disabled",
+    "medium": "Medium",
+    "off": "Off",
+    "on": "On",
     "report": "Security Report",
     "root_user": "Root User",
     "root_user_status": "Root User Status",
@@ -22,5 +26,9 @@
         "kext-loading": "KEXT Loading",
         "all-approved": "Open",
         "user-approved": "User Approved"
-    }
+    },
+    "t2_secureboot": "Secure Boot",
+    "t2_externalboot": "External Boot",
+    "unknown": "Unknown",
+    "unsupported": "Unsupported"
 }

--- a/migrations/2020_01_31_000001_security_add_secureboot_externalboot.php
+++ b/migrations/2020_01_31_000001_security_add_secureboot_externalboot.php
@@ -13,7 +13,9 @@ class SecurityAddSecurebootExternalboot extends Migration
         $capsule::schema()->table($this->tableName, function (Blueprint $table) {
           $table->string('t2_secureboot')->default('')->nullable();
           $table->string('t2_externalboot')->default('')->nullable();
-          $table->index('t2_secureboot', 't2_externalboot');
+          $table->index('t2_secureboot');
+          $table->index('t2_externalboot');
+          
         });
     }
     

--- a/migrations/2020_01_31_000001_security_add_secureboot_externalboot.php
+++ b/migrations/2020_01_31_000001_security_add_secureboot_externalboot.php
@@ -1,0 +1,28 @@
+<?php
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Capsule\Manager as Capsule;
+
+class SecurityAddSecurebootExternalboot extends Migration
+{
+    private $tableName = 'security';
+
+    public function up()
+    {
+        $capsule = new Capsule();
+        $capsule::schema()->table($this->tableName, function (Blueprint $table) {
+          $table->string('t2_secureboot')->default('')->nullable();
+          $table->string('t2_externalboot')->default('')->nullable();
+          $table->index('t2_secureboot', 't2_externalboot');
+        });
+    }
+    
+    public function down()
+    {
+        $capsule = new Capsule();
+        $capsule::schema()->table($this->tableName, function (Blueprint $table) {
+            $table->dropColumn('t2_secureboot');
+            $table->dropColumn('t2_externalboot');
+        });
+    }
+}

--- a/provides.php
+++ b/provides.php
@@ -14,7 +14,9 @@ return array(
         'firewall_state' => array('view' => 'firewall_state_widget'),
         'skel_state' => array('view' => 'skel_state_widget'),
         'root_user' => array('view' => 'root_user_widget'),
-	'ssh_state' => array('view' => 'ssh_state_widget'),
+	    'ssh_state' => array('view' => 'ssh_state_widget'),
+	    't2_externalboot' => array('view' => 't2_externalboot_widget'),
+	    't2_secureboot' => array('view' => 't2_secureboot_widget'),
     ),
     'reports' => array(
         'security' => array('view' => 'security', 'i18n' => 'security.report'),

--- a/scripts/security.py
+++ b/scripts/security.py
@@ -177,11 +177,14 @@ def ssh_group_access_check():
 
             # Translate group UUIDs to gids
             group_list = []
-            for group_uuid in group_list_uuid[1:]:
-                group_id_sp = subprocess.Popen(['dsmemberutil', 'getid', '-x', group_uuid], stdout=subprocess.PIPE)
-                group_id_out, group_id_err = group_id_sp.communicate()
-                group_list.append(grp.getgrgid(group_id_out.split()[1]).gr_name)
-
+            try:
+                for group_uuid in group_list_uuid[1:]:
+                    group_id_sp = subprocess.Popen(['dsmemberutil', 'getid', '-x', group_uuid], stdout=subprocess.PIPE)
+                    group_id_out, group_id_err = group_id_sp.communicate()
+                    group_list.append(grp.getgrgid(group_id_out.split()[1]).gr_name)
+            except IndexError:
+                pass
+                
             return ', '.join(item for item in group_list)
 
         else:
@@ -337,14 +340,17 @@ def ard_group_access_check():
                     group_list_uuid = group_out.split()
 
                     # Translate group UUIDs to gids
-                    for group_uuid in group_list_uuid[1:]:
-                        group_id_sp = subprocess.Popen(['dsmemberutil', 'getid', '-x', group_uuid], stdout=subprocess.PIPE)
-                        group_id_out, group_id_err = group_id_sp.communicate()
-                        if group_id_sp.returncode == 0:
-                            group_name = grp.getgrgid(group_id_out.split()[1]).gr_name
-                            if group_name not in group_list:
-                                group_list.append(group_name)
-
+                    try:
+                        for group_uuid in group_list_uuid[1:]:
+                            group_id_sp = subprocess.Popen(['dsmemberutil', 'getid', '-x', group_uuid], stdout=subprocess.PIPE)
+                            group_id_out, group_id_err = group_id_sp.communicate()
+                            if group_id_sp.returncode == 0:
+                                group_name = grp.getgrgid(group_id_out.split()[1]).gr_name
+                                if group_name not in group_list:
+                                    group_list.append(group_name)
+                    except IndexError:
+                        pass
+                        
             return ', '.join(item for item in group_list)
 
 #            return group_list

--- a/scripts/security.py
+++ b/scripts/security.py
@@ -28,6 +28,55 @@ def gatekeeper_check():
     else:
         return "Not Supported"
 
+def t2_chip_check():
+    """ Checks if T2 chip is present."""
+
+    sp = subprocess.Popen(['system_profiler', 'SPiBridgeDataType'], stdout=subprocess.PIPE)
+    out, err = sp.communicate()
+    if "Apple T2" in out:
+        return True
+    else:
+        return False
+
+def t2_secureboot_check():
+    """ Checks Secure Boot settings from nvram.  T2 chip models only. """
+
+    if t2_chip_check():
+        sp = subprocess.Popen(['nvram', '94b73556-2197-4702-82a8-3e1337dafbfb:AppleSecureBootPolicy'], stdout=subprocess.PIPE)
+        out, err = sp.communicate()
+        out_value = out.split("\t")[1].rstrip() 
+
+        if "%02" in out_value:
+            secureboot_value = "SECUREBOOT_FULL"
+        elif "%01" in out_value:
+            secureboot_value = "SECUREBOOT_MEDIUM"
+        elif "%00" in out_value:
+            secureboot_value = "SECUREBOOT_OFF"
+        else:
+            secureboot_value = "SECUREBOOT_UNKNOWN"           
+    else:
+        secureboot_value = "SECUREBOOT_UNSUPPORTED"
+
+    return secureboot_value
+
+def t2_externalboot_check():
+    """ Checks External Boot settings from nvram.  T2 chip models only. """
+
+    if t2_chip_check():
+        sp = subprocess.Popen(['nvram', '5eeb160f-45fb-4ce9-b4e3-610359abf6f8:StartupManagerPolicy'], stdout=subprocess.PIPE)
+        out, err = sp.communicate()
+        out_value = out.split("\t")[1].rstrip()
+        
+        if "%03" in out_value:
+            externalboot_value = "EXTERNALBOOT_ON"
+        elif "%00" in out_value:
+            externalboot_value = "EXTERNALBOOT_OFF"
+        else:
+            externalboot_value = "EXTERNALBOOT_UNKNOWN"           
+    else:
+        externalboot_value = "EXTERNALBOOT_UNSUPPORTED"
+    
+    return externalboot_value
 
 def sip_check():
     """ SIP checks. We need to be running 10.11 or newer."""
@@ -402,6 +451,9 @@ def main():
     result.update({'firewall_state':firewall_enable_check()})
     result.update({'skel_state':skel_state_check()})
     result.update({'root_user':root_enabled_check()})
+    result.update({'t2_secureboot': t2_secureboot_check()})
+    result.update({'t2_externalboot': t2_externalboot_check()})
+    
 
     # Write results of checks to cache file
     output_plist = os.path.join(cachedir, 'security.plist')

--- a/security_controller.php
+++ b/security_controller.php
@@ -210,5 +210,51 @@ class Security_controller extends Module_controller
         $obj->view('json', array('msg' => $out));
     }
 
+    /**
+     * Get secure boot statistics
+     *
+     * @return void
+     * @author eholtam
+     **/
+    public function get_secureboot_stats()
+    {
+        $obj = new View();
+
+        if (! $this->authorized()) {
+            $obj->view('json', array('msg' => array('error' => 'Not authenticated')));
+            return;
+        }
+                $secureboot_report = new Security_model;
+
+                $out = array();
+                $out['stats'] = $secureboot_report->get_secureboot_stats();
+
+
+        $obj->view('json', array('msg' => $out));
+    }
+
+    /**
+     * Get external boot statistics
+     *
+     * @return void
+     * @author eholtam
+     **/
+    public function get_externalboot_stats()
+    {
+        $obj = new View();
+
+        if (! $this->authorized()) {
+            $obj->view('json', array('msg' => array('error' => 'Not authenticated')));
+            return;
+        }
+                $externalboot_report = new Security_model;
+
+                $out = array();
+                $out['stats'] = $externalboot_report->get_externalboot_stats();
+
+
+        $obj->view('json', array('msg' => $out));
+    }
+
 
 } // END class default_module

--- a/security_model.php
+++ b/security_model.php
@@ -148,9 +148,9 @@ class Security_model extends \Model
     public function get_externalboot_stats()
     {
 	$sql = "SELECT COUNT(CASE WHEN t2_externalboot = 'EXTERNALBOOT_ON' THEN 1 END) AS externalbooton,
-		SELECT COUNT(CASE WHEN t2_externalboot = 'EXTERNALBOOT_OFF' THEN 1 END) AS externalbootoff,
-		SELECT COUNT(CASE WHEN t2_externalboot = 'EXTERNALBOOT_UNKNOWN' THEN 1 END) AS externalbootunknown,
-		SELECT COUNT(CASE WHEN t2_externalboot = 'EXTERNALBOOT_UNSUPPORTED' THEN 1 END) AS externalbootunsupported
+		COUNT(CASE WHEN t2_externalboot = 'EXTERNALBOOT_OFF' THEN 1 END) AS externalbootoff,
+		COUNT(CASE WHEN t2_externalboot = 'EXTERNALBOOT_UNKNOWN' THEN 1 END) AS externalbootunknown,
+		COUNT(CASE WHEN t2_externalboot = 'EXTERNALBOOT_UNSUPPORTED' THEN 1 END) AS externalbootunsupported
 		FROM security
 		LEFT JOIN reportdata USING(serial_number)
 		".get_machine_group_filter();

--- a/security_model.php
+++ b/security_model.php
@@ -19,6 +19,8 @@ class Security_model extends \Model
         $this->rs['firewall_state'] = '';
         $this->rs['skel_state'] = '';
         $this->rs['root_user'] = '';
+        $this->rs['t2_secureboot'] = '';
+        $this->rs['t2_externalboot'] = '';
 
         if ($serial) {
             $this->retrieve_record($serial);
@@ -48,7 +50,7 @@ class Security_model extends \Model
 
     		$plist = $parser->toArray();
 
-    		foreach (array('sip', 'gatekeeper', 'ssh_groups', 'ssh_users', 'ard_groups', 'ard_users', 'firmwarepw', 'firewall_state', 'skel_state', 'root_user') as $item) {
+    		foreach (array('sip', 'gatekeeper', 'ssh_groups', 'ssh_users', 'ard_groups', 'ard_users', 'firmwarepw', 'firewall_state', 'skel_state', 'root_user', 't2_secureboot', 't2_externalboot') as $item) {
     			if (isset($plist[$item])) {
     				$this->$item = $plist[$item];
     			} else {
@@ -128,6 +130,31 @@ class Security_model extends \Model
                 LEFT JOIN reportdata USING(serial_number)
             ".get_machine_group_filter();
     return current($this->query($sql));
+    }
+
+    public function get_secureboot_stats()
+    {
+	$sql = "SELECT COUNT(CASE WHEN t2_secureboot = 'SECUREBOOT_FULL' THEN 1 END) AS securebootfull,
+		COUNT(CASE WHEN t2_secureboot = 'SECUREBOOT_MEDIUM' THEN 1 END) AS securebootmedium,
+		COUNT(CASE WHEN t2_secureboot = 'SECUREBOOT_OFF' THEN 1 END) AS securebootoff,
+		COUNT(CASE WHEN t2_secureboot = 'SECUREBOOT_UNKNOWN' THEN 1 END) AS securebootunknown,
+		COUNT(CASE WHEN t2_secureboot = 'SECUREBOOT_UNSUPPORTED' THEN 1 END) AS securebootunsupported
+		FROM security
+		LEFT JOIN reportdata USING(serial_number)
+		".get_machine_group_filter();
+	return current($this->query($sql));
+    }
+
+    public function get_externalboot_stats()
+    {
+	$sql = "SELECT COUNT(CASE WHEN t2_externalboot = 'EXTERNALBOOT_ON' THEN 1 END) AS externalbooton,
+		SELECT COUNT(CASE WHEN t2_externalboot = 'EXTERNALBOOT_OFF' THEN 1 END) AS externalbootoff,
+		SELECT COUNT(CASE WHEN t2_externalboot = 'EXTERNALBOOT_UNKNOWN' THEN 1 END) AS externalbootunknown,
+		SELECT COUNT(CASE WHEN t2_externalboot = 'EXTERNALBOOT_UNSUPPORTED' THEN 1 END) AS externalbootunsupported
+		FROM security
+		LEFT JOIN reportdata USING(serial_number)
+		".get_machine_group_filter();
+	return current($this->query($sql));
     }
 
 }

--- a/views/security.php
+++ b/views/security.php
@@ -36,6 +36,14 @@
 
     </div> <!-- /row -->
 
+    <div class="row">
+
+        <?php $widget->view($this, 't2_secureboot'); ?>
+
+        <?php $widget->view($this, 't2_externalboot'); ?>
+
+    </div> <!-- /row -->
+
 
 </div>  <!-- /container -->
 

--- a/views/security_detail_widget.php
+++ b/views/security_detail_widget.php
@@ -58,12 +58,29 @@ $(document).on('appReady', function(){
                     .append($('<th>')
                         .text(i18n.t('security.t2_secureboot')))
                     .append($('<td>')
-                        .text(item.t2_secureboot)))
+                        .text(function(){
+                            if(item.t2_secureboot == 'SECUREBOOT_OFF'){
+                                return i18n.t('security.off');
+                            }
+                            if(item.t2_secureboot == 'SECUREBOOT_MEDIUM'){
+                            return i18n.t('security.medium');
+                            }
+                            if(item.t2_secureboot == 'SECUREBOOT_FULL'){
+                            return i18n.t('security.full');
+                            }
+                        })))
                 .append($('<tr>')
                     .append($('<th>')
                         .text(i18n.t('security.t2_externalboot')))
                     .append($('<td>')
-                        .text(item.t2_externalboot)));
+                        .text(function(){
+                            if(item.t2_externalboot == 'EXTERNALBOOT_OFF'){
+                                return i18n.t('security.off');
+                            }
+                            if(item.t2_externalboot == 'EXTERNALBOOT_ON'){
+                                return i18n.t('security.on');
+                            }
+                        })))
 		});
     });
 });

--- a/views/security_detail_widget.php
+++ b/views/security_detail_widget.php
@@ -68,6 +68,9 @@ $(document).on('appReady', function(){
                             if(item.t2_secureboot == 'SECUREBOOT_FULL'){
                             return i18n.t('security.full');
                             }
+                            if(item.t2_secureboot == 'SECUREBOOT_UNSUPPORTED'){
+                            return i18n.t('security.unsupported');
+                            }
                         })))
                 .append($('<tr>')
                     .append($('<th>')
@@ -80,7 +83,10 @@ $(document).on('appReady', function(){
                             if(item.t2_externalboot == 'EXTERNALBOOT_ON'){
                                 return i18n.t('security.on');
                             }
-                        })))
+                             if(item.t2_externalboot == 'EXTERNALBOOT_UNSUPPORTED'){
+                                return i18n.t('security.unsupported');
+                            }
+                       })))
 		});
     });
 });

--- a/views/security_detail_widget.php
+++ b/views/security_detail_widget.php
@@ -1,40 +1,71 @@
 <div class="col-lg-4">
     <h4><i class="fa fa-key fa-fixed"></i> <span data-i18n="security.security"></span></h4>
-    <table>
-        <tr>
-            <th data-i18n="security.gatekeeper"></th><td class="mr-gatekeeper"></td>
-        </tr>
-        <tr>
-            <th data-i18n="security.sip"></th><td class="mr-sip"></td>
-        </tr>
-        <tr>
-            <th data-i18n="security.ssh_groups"></th><td class="mr-ssh_groups"></td>
-        </tr>
-        <tr>
-            <th data-i18n="security.ssh_users"></th><td class="mr-ssh_users"></td>
-        </tr>
-        <tr>
-            <th data-i18n="security.ard_users"></th><td class="mr-ard_users"></td>
-        </tr>
-        <tr>
-            <th data-i18n="security.ard_groups"></th><td class="mr-ard_groups"></td>
-        </tr>
-        <tr>
-            <th data-i18n="security.firmwarepw"></th><td class="mr-firmwarepw"></td>
-        </tr>
-        <tr>
-            <th data-i18n="security.firewall_state"></th><td class="mr-firewall_state"></td>
-        </tr>
-        <tr>
-            <th data-i18n="security.skel.kext-loading"></th><td class="mr-skel_state"></td>
-        </tr>
-    </table>
+    <table id="security-data" class="table"></table>
 </div>
 
 <script>
-
-$(document).on('appReady', function(e, lang) {
-
+$(document).on('appReady', function(){
+	// Get security data
+	$.getJSON( appUrl + '/module/security/get_data/' + serialNumber, function( data ) {
+		$.each(data, function(index, item){
+            $('#security-data')
+                .append($('<tr>')
+                    .append($('<th>')
+                        .text(i18n.t('security.gatekeeper')))
+                    .append($('<td>')
+                        .text(item.gatekeeper)))
+                .append($('<tr>')
+                    .append($('<th>')
+                        .text(i18n.t('security.sip')))
+                    .append($('<td>')
+                        .text(item.sip)))
+                .append($('<tr>')
+                    .append($('<th>')
+                        .text(i18n.t('security.ssh_groups')))
+                    .append($('<td>')
+                        .text(item.ssh_groups)))
+                .append($('<tr>')
+                    .append($('<th>')
+                        .text(i18n.t('security.ssh_users')))
+                    .append($('<td>')
+                        .text(item.ssh_users)))
+                .append($('<tr>')
+                    .append($('<th>')
+                        .text(i18n.t('security.ard_users')))
+                    .append($('<td>')
+                        .text(item.ard_users)))
+                .append($('<tr>')
+                    .append($('<th>')
+                        .text(i18n.t('security.ard_groups')))
+                    .append($('<td>')
+                        .text(item.ard_groups)))
+                .append($('<tr>')
+                    .append($('<th>')
+                        .text(i18n.t('security.firmwarepw')))
+                    .append($('<td>')
+                        .text(item.firmwarepw)))
+                .append($('<tr>')
+                    .append($('<th>')
+                        .text(i18n.t('security.firewall_state')))
+                    .append($('<td>')
+                        .text(item.firewall_state)))
+                .append($('<tr>')
+                    .append($('<th>')
+                        .text(i18n.t('security.skel.kext-loading')))
+                    .append($('<td>')
+                        .text(item.skel_state)))
+                .append($('<tr>')
+                    .append($('<th>')
+                        .text(i18n.t('security.t2_secureboot')))
+                    .append($('<td>')
+                        .text(item.t2_secureboot)))
+                .append($('<tr>')
+                    .append($('<th>')
+                        .text(i18n.t('security.t2_externalboot')))
+                    .append($('<td>')
+                        .text(item.t2_externalboot)));
+		});
+    });
 });
-
 </script>
+

--- a/views/security_listing.php
+++ b/views/security_listing.php
@@ -204,7 +204,7 @@
                 } else if (secure_boot == 'SECUREBOOT_MEDIUM'){
                     return '<span class="label label-warning">'+i18n.t('security.medium')+'</span>';
                 } else if (secure_boot == 'SECUREBOOT_OFF'){
-                    return '<span class="label label-warning">'+i18n.t('security.off')+'</span>';
+                    return '<span class="label label-danger">'+i18n.t('security.off')+'</span>';
                 }
                 // if root_user is null, we don't have data
                 return '<span class="label label-default">'+i18n.t('unknown')+'</span>';
@@ -213,9 +213,9 @@
             var external_boot = $('td:eq(18)', nRow).html();
             $('td:eq(18)', nRow).html(function(){
                 if(external_boot == 'EXTERNALBOOT_ON'){
-                    return '<span class="label label-success">'+i18n.t('security.on')+'</span>';
+                    return '<span class="label label-danger">'+i18n.t('security.on')+'</span>';
                 } else if (external_boot == 'EXTERNALBOOT_OFF'){
-                    return '<span class="label label-warning">'+i18n.t('security.off')+'</span>';
+                    return '<span class="label label-success">'+i18n.t('security.off')+'</span>';
                 }
                 // if root_user is null, we don't have data
                 return '<span class="label label-default">'+i18n.t('unknown')+'</span>';

--- a/views/security_listing.php
+++ b/views/security_listing.php
@@ -28,6 +28,8 @@
 		        <th data-i18n="security.ard_users" data-colname='security.ard_users'></th>
                 <th data-i18n="security.ard_groups" data-colname='security.ard_groups'></th>
                 <th data-i18n="security.root_user" data-colname='security.root_user'></th>
+                <th data-i18n="security.t2_secureboot" data-colname='security.t2_secureboot'></th>
+                <th data-i18n="security.t2_externalboot" data-colname='security.t2_externalboot'></th>
 		      </tr>
 		    </thead>
 		    <tbody>

--- a/views/security_listing.php
+++ b/views/security_listing.php
@@ -197,6 +197,30 @@
                 return '<span class="label label-default">'+i18n.t('unknown')+'</span>';
             });
 
+            var secure_boot = $('td:eq(17)', nRow).html();
+            $('td:eq(17)', nRow).html(function(){
+                if(secure_boot == 'SECUREBOOT_FULL'){
+                    return '<span class="label label-success">'+i18n.t('security.full')+'</span>';
+                } else if (secure_boot == 'SECUREBOOT_MEDIUM'){
+                    return '<span class="label label-warning">'+i18n.t('security.medium')+'</span>';
+                } else if (secure_boot == 'SECUREBOOT_OFF'){
+                    return '<span class="label label-warning">'+i18n.t('security.off')+'</span>';
+                }
+                // if root_user is null, we don't have data
+                return '<span class="label label-default">'+i18n.t('unknown')+'</span>';
+            });
+
+            var external_boot = $('td:eq(18)', nRow).html();
+            $('td:eq(18)', nRow).html(function(){
+                if(external_boot == 'EXTERNALBOOT_ON'){
+                    return '<span class="label label-success">'+i18n.t('security.on')+'</span>';
+                } else if (external_boot == 'EXTERNALBOOT_OFF'){
+                    return '<span class="label label-warning">'+i18n.t('security.off')+'</span>';
+                }
+                // if root_user is null, we don't have data
+                return '<span class="label label-default">'+i18n.t('unknown')+'</span>';
+            });
+
         }
     });
   });

--- a/views/security_listing.php
+++ b/views/security_listing.php
@@ -205,7 +205,10 @@
                     return '<span class="label label-warning">'+i18n.t('security.medium')+'</span>';
                 } else if (secure_boot == 'SECUREBOOT_OFF'){
                     return '<span class="label label-danger">'+i18n.t('security.off')+'</span>';
+                } else if (secure_boot == 'SECUREBOOT_UNSUPPORTED'){
+                    return '<span class="label label-info">'+i18n.t('security.unsupported')+'</span>';
                 }
+                
                 // if root_user is null, we don't have data
                 return '<span class="label label-default">'+i18n.t('unknown')+'</span>';
             });
@@ -216,6 +219,8 @@
                     return '<span class="label label-danger">'+i18n.t('security.on')+'</span>';
                 } else if (external_boot == 'EXTERNALBOOT_OFF'){
                     return '<span class="label label-success">'+i18n.t('security.off')+'</span>';
+                } else if (external_boot == 'EXTERNALBOOT_UNSUPPORTED'){
+                    return '<span class="label label-info">'+i18n.t('security.unsupported')+'</span>';
                 }
                 // if root_user is null, we don't have data
                 return '<span class="label label-default">'+i18n.t('unknown')+'</span>';

--- a/views/t2_externalboot_widget.php
+++ b/views/t2_externalboot_widget.php
@@ -45,8 +45,8 @@ $(document).on('appUpdate', function(e, lang) {
 
 	// Set URLs. TODO - once filtered update this to deep link
 	var url = appUrl + '/show/listing/security/security'
-	$('#t2_externalboot-externalbooton').attr('href', url)
-	$('#t2_externalboot-externalbootoff').attr('href', url)
+	$('#t2_externalboot-externalbooton').attr('href', url + "#EXTERNALBOOT_ON")
+	$('#t2_externalboot-externalbootoff').attr('href', url + "#EXTERNALBOOT_OFF")
 
         // Show no clients span
         $('#t2_externalboot-nodata').removeClass('hide');

--- a/views/t2_externalboot_widget.php
+++ b/views/t2_externalboot_widget.php
@@ -14,15 +14,15 @@
 				<div class="panel-body text-center">
 
 
-					<a id="t2_externalboot-externalbooton" class="btn btn-warning hide">
+					<a id="t2_externalboot-externalbooton" class="btn btn-danger hide">
 						<span class="t2_externalboot-count bigger-150"></span><br>
 						<span class="t2_externalboot-label"></span>
-						<span data-i18n="security.off"></span>
+						<span data-i18n="security.on"></span>
 					</a>
 					<a id="t2_externalboot-externalbootoff" class="btn btn-success hide">
 						<span class="t2_externalboot-count bigger-150"></span><br>
 						<span class="t2_externalboot-label"></span>
-						<span data-i18n="security.on"></span>
+						<span data-i18n="security.off"></span>
 					</a>
 
           <span id="t2_externalboot-nodata" data-i18n="no_clients"></span>

--- a/views/t2_externalboot_widget.php
+++ b/views/t2_externalboot_widget.php
@@ -1,0 +1,72 @@
+		<div class="col-lg-4 col-md-6">
+
+			<div class="panel panel-default">
+
+				<div class="panel-heading">
+
+					<h3 class="panel-title"><i class="fa fa-lock"></i>
+					    <span data-i18n="security.t2_externalboot"></span>
+					    <list-link data-url="/show/listing/security/security"></list-link>
+					</h3>
+
+				</div>
+
+				<div class="panel-body text-center">
+
+
+					<a id="t2_externalboot-On" class="btn btn-warning hide">
+						<span class="t2_externalboot-count bigger-150"></span><br>
+						<span class="t2_externalboot-label"></span>
+						<span data-i18n="security.off"></span>
+					</a>
+					<a id="t2_externalboot-Off" class="btn btn-success hide">
+						<span class="t2_externalboot-count bigger-150"></span><br>
+						<span class="t2_externalboot-label"></span>
+						<span data-i18n="security.on"></span>
+					</a>
+
+          <span id="t2_externalboot-nodata" data-i18n="no_clients"></span>
+
+				</div>
+
+			</div><!-- /panel -->
+
+		</div><!-- /col -->
+
+<script>
+$(document).on('appUpdate', function(e, lang) {
+
+    $.getJSON( appUrl + '/module/security/get_externalboot_stats', function( data ) {
+	    
+	if(data.error){
+    		//alert(data.error);
+    		return;
+    	}
+
+	// Set URLs. TODO - once filtered update this to deep link
+	var url = appUrl + '/show/listing/security/security'
+	$('#EXTERNALBOOT_ON').attr('href', url)
+	$('#EXTERNALBOOT_OFF').attr('href', url)
+
+        // Show no clients span
+        $('#t2_externalboot-nodata').removeClass('hide');
+
+        $.each(data.stats, function(prop, val){
+            if(val >= 0)
+            {
+                $('#t2_externalboot-' + prop).removeClass('hide');
+                $('#t2_externalboot-' + prop + '>span.t2_externalboot-count').text(val);
+
+                // Hide no clients span
+                $('#t2_externalboot-nodata').addClass('hide');
+            }
+            else
+            {
+                $('#t2_externalboot-' + prop).addClass('hide');
+            }
+        });
+    });
+});
+
+
+</script>

--- a/views/t2_externalboot_widget.php
+++ b/views/t2_externalboot_widget.php
@@ -4,7 +4,7 @@
 
 				<div class="panel-heading">
 
-					<h3 class="panel-title"><i class="fa fa-lock"></i>
+					<h3 class="panel-title"><i class="fa fa-external-link-square"></i>
 					    <span data-i18n="security.t2_externalboot"></span>
 					    <list-link data-url="/show/listing/security/security"></list-link>
 					</h3>

--- a/views/t2_externalboot_widget.php
+++ b/views/t2_externalboot_widget.php
@@ -45,8 +45,8 @@ $(document).on('appUpdate', function(e, lang) {
 
 	// Set URLs. TODO - once filtered update this to deep link
 	var url = appUrl + '/show/listing/security/security'
-	$('#EXTERNALBOOT_ON').attr('href', url)
-	$('#EXTERNALBOOT_OFF').attr('href', url)
+	$('#t2_externalboot-On').attr('href', url)
+	$('#t2_externalboot-Off').attr('href', url)
 
         // Show no clients span
         $('#t2_externalboot-nodata').removeClass('hide');

--- a/views/t2_externalboot_widget.php
+++ b/views/t2_externalboot_widget.php
@@ -14,12 +14,12 @@
 				<div class="panel-body text-center">
 
 
-					<a id="t2_externalboot-On" class="btn btn-warning hide">
+					<a id="t2_externalboot-externalbooton" class="btn btn-warning hide">
 						<span class="t2_externalboot-count bigger-150"></span><br>
 						<span class="t2_externalboot-label"></span>
 						<span data-i18n="security.off"></span>
 					</a>
-					<a id="t2_externalboot-Off" class="btn btn-success hide">
+					<a id="t2_externalboot-externalbootoff" class="btn btn-success hide">
 						<span class="t2_externalboot-count bigger-150"></span><br>
 						<span class="t2_externalboot-label"></span>
 						<span data-i18n="security.on"></span>

--- a/views/t2_externalboot_widget.php
+++ b/views/t2_externalboot_widget.php
@@ -45,8 +45,8 @@ $(document).on('appUpdate', function(e, lang) {
 
 	// Set URLs. TODO - once filtered update this to deep link
 	var url = appUrl + '/show/listing/security/security'
-	$('#t2_externalboot-On').attr('href', url)
-	$('#t2_externalboot-Off').attr('href', url)
+	$('#t2_externalboot-externalbooton').attr('href', url)
+	$('#t2_externalboot-externalbootoff').attr('href', url)
 
         // Show no clients span
         $('#t2_externalboot-nodata').removeClass('hide');

--- a/views/t2_secureboot_widget.php
+++ b/views/t2_secureboot_widget.php
@@ -4,7 +4,7 @@
 
 				<div class="panel-heading">
 
-					<h3 class="panel-title"><i class="fa fa-lock"></i>
+					<h3 class="panel-title"><i class="fa fa-shield"></i>
 					    <span data-i18n="security.t2_secureboot"></span>
 					    <list-link data-url="/show/listing/security/security"></list-link>
 					</h3>

--- a/views/t2_secureboot_widget.php
+++ b/views/t2_secureboot_widget.php
@@ -14,12 +14,12 @@
 				<div class="panel-body text-center">
 
 
-					<a id="t2_secureboot-securebootoff" class="btn btn-warning hide">
+					<a id="t2_secureboot-securebootoff" class="btn btn-danger hide">
 						<span class="t2_secureboot-count bigger-150"></span><br>
 						<span class="t2_secureboot-label"></span>
 						<span data-i18n="security.off"></span>
 					</a>
-					<a id="t2_secureboot-securebootmedium" class="btn btn-info hide">
+					<a id="t2_secureboot-securebootmedium" class="btn btn-warning hide">
 						<span class="t2_secureboot-count bigger-150"></span><br>
 						<span class="t2_secureboot-label"></span>
 						<span data-i18n="security.medium"></span>

--- a/views/t2_secureboot_widget.php
+++ b/views/t2_secureboot_widget.php
@@ -50,9 +50,9 @@ $(document).on('appUpdate', function(e, lang) {
 
 	// Set URLs. TODO - once filtered update this to deep link
 	var url = appUrl + '/show/listing/security/security'
-	$('#t2_secureboot-securebootoff').attr('href', url)
-	$('#t2_secureboot-securebootmedium').attr('href', url)
-	$('#t2_secureboot-securebootfull').attr('href', url)
+	$('#t2_secureboot-securebootoff').attr('href', url + "#SECUREBOOT_OFF")
+	$('#t2_secureboot-securebootmedium').attr('href', url + "#SECUREBOOT_MEDIUM")
+	$('#t2_secureboot-securebootfull').attr('href', url + "#SECUREBOOT_FULL")
 
         // Show no clients span
         $('#t2_secureboot-nodata').removeClass('hide');

--- a/views/t2_secureboot_widget.php
+++ b/views/t2_secureboot_widget.php
@@ -14,17 +14,17 @@
 				<div class="panel-body text-center">
 
 
-					<a id="t2_secureboot-Off" class="btn btn-warning hide">
+					<a id="t2_secureboot-securebootoff" class="btn btn-warning hide">
 						<span class="t2_secureboot-count bigger-150"></span><br>
 						<span class="t2_secureboot-label"></span>
 						<span data-i18n="security.off"></span>
 					</a>
-					<a id="t2_secureboot-Medium" class="btn btn-info hide">
+					<a id="t2_secureboot-securebootmedium" class="btn btn-info hide">
 						<span class="t2_secureboot-count bigger-150"></span><br>
 						<span class="t2_secureboot-label"></span>
 						<span data-i18n="security.medium"></span>
 					</a>
-					<a id="t2_secureboot-Full" class="btn btn-success hide">
+					<a id="t2_secureboot-securebootfull" class="btn btn-success hide">
 						<span class="t2_secureboot-count bigger-150"></span><br>
 						<span class="t2_secureboot-label"></span>
 						<span data-i18n="security.full"></span>

--- a/views/t2_secureboot_widget.php
+++ b/views/t2_secureboot_widget.php
@@ -50,9 +50,9 @@ $(document).on('appUpdate', function(e, lang) {
 
 	// Set URLs. TODO - once filtered update this to deep link
 	var url = appUrl + '/show/listing/security/security'
-	$('#SECUREBOOT_OFF').attr('href', url)
-	$('#SECUREBOOT_MEDIUM').attr('href', url)
-	$('#SECUREBOOT_FULL').attr('href', url)
+	$('#t2_secureboot-Off').attr('href', url)
+	$('#t2_secureboot-Medium').attr('href', url)
+	$('#t2_secureboot-Full').attr('href', url)
 
         // Show no clients span
         $('#t2_secureboot-nodata').removeClass('hide');

--- a/views/t2_secureboot_widget.php
+++ b/views/t2_secureboot_widget.php
@@ -1,0 +1,78 @@
+		<div class="col-lg-4 col-md-6">
+
+			<div class="panel panel-default">
+
+				<div class="panel-heading">
+
+					<h3 class="panel-title"><i class="fa fa-lock"></i>
+					    <span data-i18n="security.t2_secureboot"></span>
+					    <list-link data-url="/show/listing/security/security"></list-link>
+					</h3>
+
+				</div>
+
+				<div class="panel-body text-center">
+
+
+					<a id="t2_secureboot-Off" class="btn btn-warning hide">
+						<span class="t2_secureboot-count bigger-150"></span><br>
+						<span class="t2_secureboot-label"></span>
+						<span data-i18n="security.off"></span>
+					</a>
+					<a id="t2_secureboot-Medium" class="btn btn-info hide">
+						<span class="t2_secureboot-count bigger-150"></span><br>
+						<span class="t2_secureboot-label"></span>
+						<span data-i18n="security.medium"></span>
+					</a>
+					<a id="t2_secureboot-Full" class="btn btn-success hide">
+						<span class="t2_secureboot-count bigger-150"></span><br>
+						<span class="t2_secureboot-label"></span>
+						<span data-i18n="security.full"></span>
+					</a>
+
+          <span id="t2_secureboot-nodata" data-i18n="no_clients"></span>
+
+				</div>
+
+			</div><!-- /panel -->
+
+		</div><!-- /col -->
+
+<script>
+$(document).on('appUpdate', function(e, lang) {
+
+    $.getJSON( appUrl + '/module/security/get_secureboot_stats', function( data ) {
+	    
+	if(data.error){
+    		//alert(data.error);
+    		return;
+    	}
+
+	// Set URLs. TODO - once filtered update this to deep link
+	var url = appUrl + '/show/listing/security/security'
+	$('#SECUREBOOT_OFF').attr('href', url)
+	$('#SECUREBOOT_MEDIUM').attr('href', url)
+	$('#SECUREBOOT_FULL').attr('href', url)
+
+        // Show no clients span
+        $('#t2_secureboot-nodata').removeClass('hide');
+
+        $.each(data.stats, function(prop, val){
+            if(val >= 0)
+            {
+                $('#t2_secureboot-' + prop).removeClass('hide');
+                $('#t2_secureboot-' + prop + '>span.t2_secureboot-count').text(val);
+
+                // Hide no clients span
+                $('#t2_secureboot-nodata').addClass('hide');
+            }
+            else
+            {
+                $('#t2_secureboot-' + prop).addClass('hide');
+            }
+        });
+    });
+});
+
+
+</script>

--- a/views/t2_secureboot_widget.php
+++ b/views/t2_secureboot_widget.php
@@ -50,9 +50,9 @@ $(document).on('appUpdate', function(e, lang) {
 
 	// Set URLs. TODO - once filtered update this to deep link
 	var url = appUrl + '/show/listing/security/security'
-	$('#t2_secureboot-Off').attr('href', url)
-	$('#t2_secureboot-Medium').attr('href', url)
-	$('#t2_secureboot-Full').attr('href', url)
+	$('#t2_secureboot-securebootoff').attr('href', url)
+	$('#t2_secureboot-securebootmedium').attr('href', url)
+	$('#t2_secureboot-securebootfull').attr('href', url)
 
         // Show no clients span
         $('#t2_secureboot-nodata').removeClass('hide');


### PR DESCRIPTION
SecureBoot and ExternalBoot settings are part of the T2 security settings set in nvram. The nvram key names can be found in a sysdiagnose archive in the `securebootvariables.txt` file.

SecureBoot has 3 settings -- Full, Medium, and Off.
ExternalBoot has 2 settings -- On and Off.

PR Adds:
- Client script reports on SecureBoot and ExternalBoot settings if the machine has a T2 chip. The features are only for T2 systems.

- 2 widgets -- one for each data set and added to the Security Report.  Widget buttons link to unique search terms for each button value.

- Updated Security listing to include the SecureBoot and ExternalBoot columns.  Colorized for quick viewing.  Unsupported model report as such to see that there is empirical data for each machine.

- Migration to add the two new data columns to the DB.

<img width="327" alt="Screenshot 2020-01-31 23 05 02" src="https://user-images.githubusercontent.com/1416288/73587403-ca5fcc80-4480-11ea-9ad7-d4a558b37db9.png">

<img width="1013" alt="Screenshot 2020-01-31 23 05 11" src="https://user-images.githubusercontent.com/1416288/73587404-cc299000-4480-11ea-8b00-32b7ee2c4d62.png">

