### PR TITLE
Update Security client listing to show FileVault status based on filevault_status table

### DIFF
--- a/views/security_listing.php
+++ b/views/security_listing.php
@@ -94,15 +94,6 @@
                         d.search.value = '';
                     }
 
-                    // Only search on bootvolume
-                    d.where = [
-                        {
-                            table: 'diskreport',
-                            column: 'mountpoint',
-                            value: '/'
-                        }
-                    ];
-
                 }
             },
             dom: mr.dt.buttonDom,

--- a/views/security_listing.php
+++ b/views/security_listing.php
@@ -12,7 +12,7 @@
 		        <th data-i18n="username" data-colname='reportdata.long_username'></th>
 		        <th data-i18n="filevault_status.users" data-colname='filevault_status.filevault_users'></th>
 		        <th data-i18n="type"data-colname='machine.machine_name'></th>
-		        <th data-i18n="disk_report.encryption_status" data-colname='diskreport.encrypted'></th>
+		        <th data-i18n="filevault_status.filevault_status" data-colname='filevault_status.filevault_status'></th>
 		        <th data-i18n="security.gatekeeper" data-colname='security.gatekeeper'></th>
 		        <th data-i18n="security.sip" data-colname='security.sip'></th>
 		        <th data-i18n="security.firmwarepw" data-colname='security.firmwarepw'></th>

--- a/views/security_listing.php
+++ b/views/security_listing.php
@@ -11,7 +11,7 @@
 		        <th data-i18n="serial" data-colname='reportdata.serial_number'></th>
 		        <th data-i18n="username" data-colname='reportdata.long_username'></th>
 		        <th data-i18n="filevault_status.users" data-colname='filevault_status.filevault_users'></th>
-		        <th data-i18n="type"data-colname='machine.machine_name'></th>
+		        <th data-i18n="type" data-colname='machine.machine_name'></th>
 		        <th data-i18n="filevault_status.filevault_status" data-colname='filevault_status.filevault_status'></th>
 		        <th data-i18n="security.gatekeeper" data-colname='security.gatekeeper'></th>
 		        <th data-i18n="security.sip" data-colname='security.sip'></th>


### PR DESCRIPTION
## Issue
https://github.com/munkireport/munkireport-php/issues/1394

## Details of PR
Fixes the client listing for Security to show the FileVault status based on the `filevault_status` table, which is more up to date than the disk report one. This does not address the FileVault status widget in the Security report, though. That could be a separate PR.

## Related PR
The Disk Report module uses the Security client listing for encrypted/unencrypted, so this PR would fix what that click from Disk Report to Security client listing would look like
https://github.com/munkireport/disk_report/pull/16

## Testing Done
Before PR
![Screen Shot 2021-06-23 at 1 06 25 PM](https://user-images.githubusercontent.com/13055957/123161374-2a636400-d424-11eb-8867-a07e68328a6a.png)

After PR
![Screen Shot 2021-06-23 at 1 05 49 PM](https://user-images.githubusercontent.com/13055957/123161397-30594500-d424-11eb-95a9-1329060fea37.png)
