### PR TITLE
Use FileVault widget instead of Disk Report widget for FileVault status

### DIFF
--- a/views/security.php
+++ b/views/security.php
@@ -12,7 +12,7 @@
 
 		<?php $widget->view($this, 'sip'); ?>
 
-		<?php $widget->view($this, 'filevault'); ?>
+		<?php $widget->view($this, 'filevault_status'); ?>
 
 	</div> <!-- /row -->
 


### PR DESCRIPTION
## Details of PR
The `disk_report` module's FileVault status widget is broken on Catalina and Big Sur.
This PR changes to `security` using the `filevault` module's widget instead.

## Testing Done
Before PR for Big Sur encrypted client
![Screen Shot 2021-06-25 at 12 21 22 PM](https://user-images.githubusercontent.com/13055957/123475649-8bb83e00-d5b0-11eb-9107-64c6edfd8269.png)

After PR for Big Sur encrypted client
![Screen Shot 2021-06-25 at 12 22 24 PM](https://user-images.githubusercontent.com/13055957/123475664-907cf200-d5b0-11eb-9feb-681582b3d4b0.png)
