### PR TITLE
Update security.py

### DIFF
--- a/scripts/security.py
+++ b/scripts/security.py
@@ -414,8 +414,7 @@ def firmware_pw_check():
     The command firmwarepassword appeared in 10.10, so we use nvram for older versions.
     Thank you @steffan for this check."""
     # Firmware passwords not supported on Apple Silicon - return No if we are running it
-    sp = subprocess.Popen(['/usr/bin/arch'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    out, err = sp.communicate()
+    out = reportcommon.get_cpuarch()
     if 'arm64' in out:
         return "Not Supported"
 

--- a/scripts/security.py
+++ b/scripts/security.py
@@ -416,7 +416,13 @@ def firmware_pw_check():
     The command firmwarepassword appeared in 10.10, so we use nvram for older versions.
     Thank you @steffan for this check."""
     # Firmware passwords not supported on Apple Silicon - return No if we are running it
-    out = reportcommon.get_cpuarch()
+    try:
+        arch_output = subprocess.check_output(["/usr/bin/arch", "-arm64", "/usr/bin/uname", "-m"], stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError:
+        arch_output = subprocess.check_output(["/usr/bin/uname", "-m"])
+    
+    out = arch_output.decode("utf-8").strip()
+
     if 'arm64' in out:
         return "Not Supported"
 

--- a/scripts/security.py
+++ b/scripts/security.py
@@ -415,14 +415,8 @@ def firmware_pw_check():
     The command firmwarepassword appeared in 10.10, so we use nvram for older versions.
     Thank you @steffan for this check."""
     # Firmware passwords not supported on Apple Silicon - return No if we are running it
-    try:
-        arch_output = subprocess.check_output(["/usr/bin/arch", "-arm64", "/usr/bin/uname", "-m"], stderr=subprocess.STDOUT)
-    except subprocess.CalledProcessError:
-        arch_output = subprocess.check_output(["/usr/bin/uname", "-m"])
-    
-    out = arch_output.decode("utf-8").strip()
 
-    if 'arm64' in out:
+    if "arm64" in os.uname()[3].lower():
         return "Not Supported"
 
     if float(os.uname()[2][0:2]) >= 14:

--- a/scripts/security.py
+++ b/scripts/security.py
@@ -12,6 +12,8 @@ sys.path.insert(0, '/usr/local/munki')
 sys.path.insert(0, '/usr/local/munkireport')
 
 from munkilib import FoundationPlist
+from munkilib import reportcommon
+
 from Foundation import CFPreferencesCopyAppValue
 
 # Disable PyLint complaining about 'invalid' names and lines too long

--- a/scripts/security.py
+++ b/scripts/security.py
@@ -12,7 +12,6 @@ sys.path.insert(0, '/usr/local/munki')
 sys.path.insert(0, '/usr/local/munkireport')
 
 from munkilib import FoundationPlist
-from munkilib import reportcommon
 
 from Foundation import CFPreferencesCopyAppValue
 


### PR DESCRIPTION
Change method for getting architecture.
With Python 2 the call to arch will always return x86_64 even on ARM hardware, so the catch to bail on ARM fails.  The value being returned when Intel hardware is expected is 'command' which is part of the error returned due to the command attempted not existing on ARM hardware.